### PR TITLE
Move app to a dedicated ASP

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ stages:
     parameters:
       SolutionBaseName: $(SolutionBaseName)
       BuildConfiguration: $(BuildConfiguration)
-    
+
 - stage: Deploy_AT
   dependsOn: Build
   displayName: Deploy to AT
@@ -64,7 +64,7 @@ stages:
   variables:
   - group: DevTest Management Resources
   - group: TEST DevTest Shared Resources
-  - group: TEST das-findanapprenticeship-web 
+  - group: TEST das-findapprenticeship-web
   jobs:
   - template: pipeline-templates/job/deploy.yml
     parameters:
@@ -91,6 +91,7 @@ stages:
   variables:
   - group: PreProd Management Resources
   - group: PreProd Shared Resources
+  - group: PreProd das-findapprenticeship-web
   jobs:
   - template: pipeline-templates/job/deploy.yml
     parameters:
@@ -104,7 +105,7 @@ stages:
 #   variables:
 #   - group: PROD Management Resources
 #   - group: PROD Shared Resources
-#   - group: __PRODSpecificReleaseVariables__ #PLACEHOLDER
+#   - group: PROD das-findapprenticeship-web
 #   jobs:
 #   - template: pipeline-templates/job/deploy.yml
 #     parameters:

--- a/azure/template.json
+++ b/azure/template.json
@@ -47,12 +47,6 @@
         "keyVaultCertificateName": {
             "type": "string"
         },
-        "sharedFrontEndAppServicePlanName": {
-            "type": "string"
-        },
-        "sharedFrontEndSubnetResourceId": {
-            "type": "string"
-        },
         "frontEndAccessRestrictions": {
             "type": "array"
         },
@@ -72,6 +66,26 @@
         },
         "stubAuth": {
             "type": "string"
+        },
+        "aspSize": {
+            "type": "string",
+            "defaultValue": "1"
+        },
+        "aspInstances": {
+            "type": "int",
+            "defaultValue": 1
+        },
+        "sharedEnvVirtualNetworkName": {
+            "type": "string"
+        },
+        "subnetObject": {
+            "type": "object"
+        },
+        "subnetServiceEndpointList": {
+            "type": "array"
+        },
+        "subnetDelegations": {
+            "type": "array"
         }
     },
     "variables": {
@@ -79,6 +93,7 @@
         "resourceNamePrefix": "[toLower(concat('das-', parameters('resourceEnvironmentName'),'-', parameters('serviceName')))]",
         "resourceGroupName": "[concat(variables('resourceNamePrefix'), '-rg')]",
         "appServiceName": "[concat(variables('resourceNamePrefix'), '-as')]",
+        "appServicePlanName": "[concat(variables('resourceNamePrefix'), '-asp')]",
         "configNames": "SFA.DAS.FindApprenticeship.Web,SFA.DAS.Candidate.GovSignIn"
     },
     "resources": [
@@ -92,9 +107,69 @@
         },
         {
             "apiVersion": "2021-04-01",
-            "name": "[concat(variables('appServiceName'), '-app-service-certificate-', parameters('utcValue'))]",
+            "name": "[concat(parameters('subnetObject').name, '-', parameters('utcValue'))]",
             "type": "Microsoft.Resources/deployments",
             "resourceGroup": "[parameters('sharedEnvResourceGroup')]",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'subnet.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "virtualNetworkName": {
+                        "value": "[parameters('sharedEnvVirtualNetworkName')]"
+                    },
+                    "subnetName": {
+                        "value": "[parameters('subnetObject').name]"
+                    },
+                    "subnetAddressPrefix": {
+                        "value": "[parameters('subnetObject').addressSpace]"
+                    },
+                    "serviceEndpointList": {
+                        "value": "[parameters('subnetServiceEndpointList')]"
+                    },
+                    "delegations": {
+                        "value": "[parameters('subnetDelegations')]"
+                    }
+                }
+            },
+            "dependsOn": [
+                "[variables('resourceGroupName')]"
+            ]
+        },
+        {
+            "apiVersion": "2021-04-01",
+            "name": "[concat(variables('appServiceName'), '-app-service-plan-', parameters('utcValue'))]",
+            "type": "Microsoft.Resources/deployments",
+            "resourceGroup": "[variables('resourceGroupName')]",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'app-service-plan.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "appServicePlanName": {
+                        "value": "[variables('appServicePlanName')]"
+                    },
+                    "aspSize": {
+                        "value": "[parameters('aspSize')]"
+                    },
+                    "aspInstances": {
+                        "value": "[parameters('aspInstances')]"
+                    }
+                }
+            },
+            "dependsOn": [
+                "[variables('resourceGroupName')]"
+            ]
+        },
+        {
+            "apiVersion": "2021-04-01",
+            "name": "[concat(variables('appServiceName'), '-app-service-certificate-', parameters('utcValue'))]",
+            "type": "Microsoft.Resources/deployments",
+            "resourceGroup": "[variables('resourceGroupName')]",
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
@@ -157,13 +232,13 @@
                         "value": "[variables('appServiceName')]"
                     },
                     "appServicePlanName": {
-                        "value": "[parameters('sharedFrontEndAppServicePlanName')]"
+                        "value": "[variables('appServicePlanName')]"
                     },
                     "appServicePlanResourceGroup": {
-                        "value": "[parameters('sharedEnvResourceGroup')]"
+                        "value": "[variables('resourceGroupName')]"
                     },
                     "subnetResourceId": {
-                        "value": "[parameters('sharedFrontEndSubnetResourceId')]"
+                        "value": "[reference(concat(parameters('subnetObject').name, '-', parameters('utcValue'))).outputs.subnetResourceId.value]"
                     },
                     "appServiceAppSettings": {
                         "value": {
@@ -223,7 +298,8 @@
                 }
             },
             "dependsOn": [
-                "[variables('resourceGroupName')]"
+                "[variables('resourceGroupName')]",
+                "[concat(variables('appServiceName'), '-app-service-plan-', parameters('utcValue'))]"
             ]
         },
         {


### PR DESCRIPTION
**Context**
Prior to v2 go-live we need to move the UI on to a dedicated ASP to ensure performance, reliability and easier scalability.

**Proposed changes**

- Remove parameters for shared ASP resources
- Add dedicated ASP deployment and parameters to ARM template
- Add dedicated subnet deployment and parameters to ARM template
- Update app service deployment to use new ASP and subnet

**Follow-up activity**
To deploy through environments:

- Add AspInstances variable to ENV das-findapprenticeship-web variable group if it deviates from the default value of 1
- As the environment stage starts to deploy, delete the `das-ENV-faav2ui-as` and staging app service from the relevant resource group
- The template should deploy the ASP, certificate to the resource group, subnet to the vnet and then redeploy the app service