### PR TITLE
FAI-2378 Reduce spacing on multiple locations on the Vacancy details page

### DIFF
--- a/src/SFA.DAS.FAA.Web/TagHelpers/AddressTagHelper.cs
+++ b/src/SFA.DAS.FAA.Web/TagHelpers/AddressTagHelper.cs
@@ -23,7 +23,7 @@ namespace SFA.DAS.FAA.Web.TagHelpers
                 return;
             }
 
-            output.TagName = Flat ? "li" : "p";
+            output.TagName = Flat ? "span" : "p";
             output.TagMode = TagMode.StartTagAndEndTag;
 
             AddCssClasses(output, Class);

--- a/src/SFA.DAS.FAA.Web/Views/Vacancies/_ClosedVacancyWhenAuthenticated.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/Vacancies/_ClosedVacancyWhenAuthenticated.cshtml
@@ -196,12 +196,12 @@
                 {
                     case AvailableWhere.MultipleLocations:
                         <p class="govuk-body">This apprenticeship is available in these locations:</p>
-                        foreach (var address in Model.Addresses)
-                        {
-                            <ul class="govuk-list govuk-list--bullet">
+                        <ul class="govuk-list govuk-list--bullet">
+                            @foreach (var address in Model.Addresses)
+                            {
                                 <address value="@address" anonymised="Model.IsAnonymousEmployer" flat="true"></address>
-                            </ul>
-                        }
+                            }
+                        </ul>
                         break;
                     case AvailableWhere.AcrossEngland:
                         <p class="govuk-body govuk-!-margin-bottom-0">@Model.EmployerDescription</p>

--- a/src/SFA.DAS.FAA.Web/Views/Vacancies/_ClosedVacancyWhenAuthenticated.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/Vacancies/_ClosedVacancyWhenAuthenticated.cshtml
@@ -199,7 +199,9 @@
                         <ul class="govuk-list govuk-list--bullet">
                             @foreach (var address in Model.Addresses)
                             {
-                                <address value="@address" anonymised="Model.IsAnonymousEmployer" flat="true"></address>
+                                <li>
+                                    <address value="@address" anonymised="Model.IsAnonymousEmployer" flat="true"></address>
+                                </li>
                             }
                         </ul>
                         break;

--- a/src/SFA.DAS.FAA.Web/Views/Vacancies/_LiveVacancy.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/Vacancies/_LiveVacancy.cshtml
@@ -262,12 +262,12 @@
                     case AvailableWhere.MultipleLocations:
                     {
                         <p class="govuk-body">This apprenticeship is available in these locations:</p>
-                        foreach (var address in Model.Addresses)
-                        {
-                            <ul class="govuk-list govuk-list--bullet">
+                        <ul class="govuk-list govuk-list--bullet">
+                            @foreach (var address in Model.Addresses)
+                            {
                                 <address value="@address" anonymised="Model.IsAnonymousEmployer" flat="true"></address>
-                            </ul>
-                        }
+                            }
+                        </ul>
                         break;
                     }
                     case AvailableWhere.AcrossEngland:

--- a/src/SFA.DAS.FAA.Web/Views/Vacancies/_LiveVacancy.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/Vacancies/_LiveVacancy.cshtml
@@ -262,12 +262,14 @@
                     case AvailableWhere.MultipleLocations:
                     {
                         <p class="govuk-body">This apprenticeship is available in these locations:</p>
-                        <ul class="govuk-list govuk-list--bullet">
-                            @foreach (var address in Model.Addresses)
-                            {
-                                <address value="@address" anonymised="Model.IsAnonymousEmployer" flat="true"></address>
-                            }
-                        </ul>
+                            <ul class="govuk-list govuk-list--bullet">
+                                @foreach (var address in Model.Addresses)
+                                {
+                                    <li>
+                                        <address value="@address" anonymised="Model.IsAnonymousEmployer" flat="true"></address>
+                                    </li>
+                                }
+                            </ul>
                         break;
                     }
                     case AvailableWhere.AcrossEngland:


### PR DESCRIPTION
✨ Refactor address display in location listings

- The address display for "MultipleLocations" was updated in both views.
- Replaced traditional `foreach` with Razor `@foreach` syntax.
- Improved readability while maintaining functionality.
- Ensured proper HTML structure by repositioning `</ul>` tag.
- Enhanced code consistency across related files.

Changes made by Balaji Jambulingam

**_Screen Grabs: Anon & Multi-city ML_**
<img width="359" alt="image" src="https://github.com/user-attachments/assets/d5102872-1553-417f-9e41-6929f57db12d" />
![image](https://github.com/user-attachments/assets/33b9be97-2f8f-45c5-84e3-1926f8a87bfe)
