### PR TITLE
FAI-2381 Default text appearing in all vacancies in FAA

### DIFF
--- a/src/SFA.DAS.FAA.Web/Views/Vacancies/_ClosedVacancyWhenAuthenticated.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/Vacancies/_ClosedVacancyWhenAuthenticated.cshtml
@@ -188,8 +188,7 @@
             <section class="faa-vacancy__section" id="work">
                 <h2 class="govuk-heading-m">Work</h2>
                 <p class="govuk-hint">
-                    As an apprentice, you’ll work at a company and get hands-on experience. You’ll gain new skills and
-                    work alongside experienced staff.
+                    Most of your apprenticeship is spent working. You’ll learn on the job by getting hands-on experience.
                 </p>
                 <h3 class="govuk-heading-s">What you’ll do at work</h3>
                 @switch (Model.EmployerLocationOption)
@@ -261,8 +260,7 @@
             <section class="faa-vacancy__section" id="training">
                 <h2 class="govuk-heading-m">Training</h2>
                 <p class="govuk-body  das-!-color-dark-grey">
-                    An apprenticeship includes regular training with a college or
-                    other training organisation. At least 20% of your working hours will be spent training or studying.
+                    Apprenticeships include time away from working for specialist training. You’ll study to gain professional knowledge and skills.
                 </p>
                 <h3 class="govuk-heading-s">College or training organisation</h3>
                 <p>@Model.TrainingProviderName</p>

--- a/src/SFA.DAS.FAA.Web/Views/Vacancies/_LiveVacancy.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/Vacancies/_LiveVacancy.cshtml
@@ -250,8 +250,7 @@
             <section class="faa-vacancy__section" id="work">
                 <h2 class="govuk-heading-m">Work</h2>
                 <p class="govuk-hint">
-                    As an apprentice, you’ll work at a company and get hands-on experience. You’ll gain new skills and
-                    work alongside experienced staff.
+                    Most of your apprenticeship is spent working. You’ll learn on the job by getting hands-on experience.
                 </p>
                 <h3 class="govuk-heading-s">What you’ll do at work</h3>
                 <p>@Html.Raw(Model.WorkDescription)</p>
@@ -328,8 +327,7 @@
             <section class="faa-vacancy__section" id="training">
                 <h2 class="govuk-heading-m">Training</h2>
                 <p class="govuk-body  das-!-color-dark-grey">
-                    An apprenticeship includes regular training with a college or
-                    other training organisation. At least 20% of your working hours will be spent training or studying.
+                    Apprenticeships include time away from working for specialist training. You’ll study to gain professional knowledge and skills.
                 </p>
                 <h3 class="govuk-heading-s">College or training organisation</h3>
                 <p>@Model.TrainingProviderName</p>


### PR DESCRIPTION
✨ Update apprenticeship descriptions in vacancy sections

- Clarified the "Work" section to emphasize hands-on experience.
- The "Training" section was revised to highlight specialized training time.
- Removed references to regular training with colleges or organizations.
- Focused on the importance of studying for professional knowledge.
- Enhanced overall clarity and relevance of apprenticeship information.

Changes made by Balaji Jambulingam