### PR TITLE
FAI-2558 BUG Invalid Level or Route ID in query string for FAA search causing 500 error

### DIFF
--- a/src/SFA.DAS.FAA.Web.UnitTests/Validators/WhenValidatingSearchRequest.cs
+++ b/src/SFA.DAS.FAA.Web.UnitTests/Validators/WhenValidatingSearchRequest.cs
@@ -1,44 +1,140 @@
-using FluentAssertions;
-using NUnit.Framework;
+using FluentValidation.TestHelper;
 using SFA.DAS.FAA.Web.Models.SearchResults;
 using SFA.DAS.FAA.Web.Validators;
 
 namespace SFA.DAS.FAA.Web.UnitTests.Validators;
 
+[TestFixture]
 public class WhenValidatingSearchRequest
 {
-    [TestCase("<script>test</script>", false)]
-    [TestCase("", true)]
-    [TestCase("an apprenticeship @! 'Brilliant'", true)]
-    [TestCase(null, true)]
-    public async Task Then_The_SearchTerm_Field_Is_Validated(string? inputValue, bool isValid)
+    [Test]
+    [MoqInlineAutoData("<script>test</script>", false)]
+    [MoqInlineAutoData("", true)]
+    [MoqInlineAutoData("an apprenticeship @! 'Brilliant'", true)]
+    [MoqInlineAutoData(null, true)]
+    public async Task Then_The_SearchTerm_Field_Is_Validated(
+        string? inputValue,
+        bool isValid,
+        [Greedy] GetSearchResultsRequestValidator validator)
     {
         var model = new GetSearchResultsRequest
         {
             SearchTerm = inputValue
         };
         
-        var validator = new GetSearchResultsRequestValidator();
-
         var actual= await validator.ValidateAsync(model);
 
         actual.IsValid.Should().Be(isValid);
     }
-    [TestCase("<script>test</script>", false)]
-    [TestCase("", true)]
-    [TestCase("LS12 5RD", true)]
-    [TestCase(null, true)]
-    public async Task Then_The_Location_Field_Is_Validated(string? inputValue, bool isValid)
+
+    [Test]
+    [MoqInlineAutoData("<script>test</script>", false)]
+    [MoqInlineAutoData("", true)]
+    [MoqInlineAutoData("LS12 5RD", true)]
+    [MoqInlineAutoData(null, true)]
+    public async Task Then_The_Location_Field_Is_Validated(
+        string? inputValue,
+        bool isValid,
+        [Greedy] GetSearchResultsRequestValidator validator)
     {
         var model = new GetSearchResultsRequest
         {
             Location = inputValue
         };
-        
-        var validator = new GetSearchResultsRequestValidator();
-
         var actual= await validator.ValidateAsync(model);
 
         actual.IsValid.Should().Be(isValid);
+    }
+
+    [Test, MoqAutoData]
+    public void Valid_Request_Passes_Validation(
+        GetSearchResultsRequest model,
+        [Greedy] GetSearchResultsRequestValidator validator)
+    {
+        // Arrange
+        model.SearchTerm = "Developer";
+        model.Location = "London";
+        model.RouteIds = ["1", "2"];
+        model.LevelIds = ["3"];
+        model.Distance = 10;
+        model.PageNumber = 1;
+        model.Sort = "AgeAsc";
+
+        // Act
+        var result = validator.TestValidate(model);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Test, MoqAutoData]
+    public void Invalid_RouteId_Should_Have_Error(GetSearchResultsRequest model,
+        [Greedy] GetSearchResultsRequestValidator validator)
+    {
+        model.RouteIds = ["abc"];
+
+        var result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor("RouteIds[0]");
+    }
+
+    [Test, MoqAutoData]
+    public void Invalid_LevelId_Should_Have_Error(
+        GetSearchResultsRequest model,
+        [Greedy] GetSearchResultsRequestValidator validator)
+    {
+        model.LevelIds = ["xyz"];
+
+        var result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor("LevelIds[0]");
+    }
+
+    [Test, MoqAutoData]
+    public void Location_Too_Long_Should_Have_Error(
+        GetSearchResultsRequest model,
+        [Greedy] GetSearchResultsRequestValidator validator)
+    {
+        model.Location = new string('a', 101);
+
+        var result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Location);
+    }
+
+    [Test, MoqAutoData]
+    public void Distance_Invalid_Should_Have_Error(
+        GetSearchResultsRequest model,
+        [Greedy] GetSearchResultsRequestValidator validator)
+    {
+        model.Distance = 99;
+
+        var result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Distance);
+    }
+
+    [Test, MoqAutoData]
+    public void PageNumber_Less_Than_One_Should_Have_Error(
+        GetSearchResultsRequest model,
+        [Greedy] GetSearchResultsRequestValidator validator)
+    {
+        model.PageNumber = 0;
+
+        var result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.PageNumber);
+    }
+
+    [Test, MoqAutoData]
+    public void Sort_Invalid_Should_Have_Error(
+        GetSearchResultsRequest model,
+        [Greedy] GetSearchResultsRequestValidator validator)
+    {
+        model.Sort = "NotAValidSort";
+
+        var result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Sort);
     }
 }

--- a/src/SFA.DAS.FAA.Web.UnitTests/Validators/WhenValidatingSearchRequest.cs
+++ b/src/SFA.DAS.FAA.Web.UnitTests/Validators/WhenValidatingSearchRequest.cs
@@ -91,18 +91,6 @@ public class WhenValidatingSearchRequest
     }
 
     [Test, MoqAutoData]
-    public void Location_Too_Long_Should_Have_Error(
-        GetSearchResultsRequest model,
-        [Greedy] GetSearchResultsRequestValidator validator)
-    {
-        model.Location = new string('a', 101);
-
-        var result = validator.TestValidate(model);
-
-        result.ShouldHaveValidationErrorFor(x => x.Location);
-    }
-
-    [Test, MoqAutoData]
     public void Distance_Invalid_Should_Have_Error(
         GetSearchResultsRequest model,
         [Greedy] GetSearchResultsRequestValidator validator)

--- a/src/SFA.DAS.FAA.Web/Controllers/SearchApprenticeshipsController.cs
+++ b/src/SFA.DAS.FAA.Web/Controllers/SearchApprenticeshipsController.cs
@@ -451,8 +451,8 @@ public class SearchApprenticeshipsController(
 
         return model.Total switch
         {
-            1 => $"{model.Total} results found",
-            <= 10 => $"{model.Total} results found",
+            1 => $"{model.Total} result found",
+            > 1 and <= 10 => $"{model.Total} results found",
             _ =>
                 $"{model.Total} results found (page {model.PaginationViewModel.CurrentPage} of {model.PaginationViewModel.TotalPages})"
         };

--- a/src/SFA.DAS.FAA.Web/Controllers/SearchApprenticeshipsController.cs
+++ b/src/SFA.DAS.FAA.Web/Controllers/SearchApprenticeshipsController.cs
@@ -234,10 +234,10 @@ public class SearchApprenticeshipsController(
         viewModel.Location = request.Location;
         viewModel.Distance = request.Distance;
         viewModel.SearchTerm = request.SearchTerm;
-        viewModel.VacancyAdverts = result.VacancyAdverts?.Any() == true
+        viewModel.VacancyAdverts = result.VacancyAdverts.Count > 0
             ? result.VacancyAdverts.Select(c => VacancyAdvertViewModel.MapToViewModel(dateTimeService, c, result.CandidateDateOfBirth)).ToList()
             : [];
-        viewModel.MapData = result.VacancyAdverts?.Any() == true
+        viewModel.MapData = result.VacancyAdverts.Count > 0
             ? result.VacancyAdverts.Select(c => ApprenticeshipMapData.MapToViewModel(dateTimeService, c, result.CandidateDateOfBirth)).ToList()
             : [];
         viewModel.MapId = faaConfiguration.Value.GoogleMapsId;

--- a/src/SFA.DAS.FAA.Web/Validators/GetSearchResultsRequestValidator.cs
+++ b/src/SFA.DAS.FAA.Web/Validators/GetSearchResultsRequestValidator.cs
@@ -10,7 +10,6 @@ public class GetSearchResultsRequestValidator : AbstractValidator<GetSearchResul
 {
     private static readonly int[] AllowedDistances = [2, 5, 10, 15, 20, 30, 40];
     private static readonly Regex NumericRegex = new(@"^\d+$", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
-    private static readonly Regex ValidFreeTextCharactersRegex = new(@"^[a-zA-Z0-9\s,'-]*$", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
 
     public GetSearchResultsRequestValidator()
     {
@@ -28,11 +27,6 @@ public class GetSearchResultsRequestValidator : AbstractValidator<GetSearchResul
             .Must(id => NumericRegex.IsMatch(id)).WithMessage("Each LevelId must be numeric.")
             .MaximumLength(10).WithMessage("LevelId must be at most 10 digits.")
             .When(x => x.LevelIds is { Count: > 0 });
-
-        RuleFor(x => x.Location)
-            .MaximumLength(100)
-            .Must(id => ValidFreeTextCharactersRegex.IsMatch(id)).WithMessage("Location contains invalid characters.")
-            .When(x => !string.IsNullOrEmpty(x.Location));
 
         RuleFor(x => x.Distance)
             .Must(value => value != null && AllowedDistances.Contains(value.Value))

--- a/src/SFA.DAS.FAA.Web/Validators/GetSearchResultsRequestValidator.cs
+++ b/src/SFA.DAS.FAA.Web/Validators/GetSearchResultsRequestValidator.cs
@@ -1,16 +1,62 @@
 using FluentValidation;
+using SFA.DAS.FAA.Domain.SearchResults;
 using SFA.DAS.FAA.Web.Models.SearchResults;
 using SFA.DAS.InputValidation.Fluent.Extensions;
+using System.Text.RegularExpressions;
 
 namespace SFA.DAS.FAA.Web.Validators;
 
 public class GetSearchResultsRequestValidator : AbstractValidator<GetSearchResultsRequest>
 {
+    private static readonly int[] AllowedDistances = [2, 5, 10, 15, 20, 30, 40];
+    private static readonly Regex NumericRegex = new(@"^\d+$", RegexOptions.Compiled);
+    private static readonly Regex ValidFreeTextCharactersRegex = new(@"^[a-zA-Z0-9\s,'-]*$", RegexOptions.Compiled);
+
     public GetSearchResultsRequestValidator()
     {
         RuleFor(x => x.SearchTerm)
             .ValidFreeTextCharacters();
         RuleFor(x => x.Location)
             .ValidFreeTextCharacters();
-    }    
+
+        RuleForEach(x => x.RouteIds)
+            .Must(id => NumericRegex.IsMatch(id)).WithMessage("Each RouteId must be numeric.")
+            .MaximumLength(10).WithMessage("RouteId must be at most 10 digits.")
+            .When(x => x.RouteIds != null && x.RouteIds.Any());
+
+        RuleForEach(x => x.LevelIds)
+            .Must(id => NumericRegex.IsMatch(id)).WithMessage("Each LevelId must be numeric.")
+            .MaximumLength(10).WithMessage("LevelId must be at most 10 digits.")
+            .When(x => x.LevelIds != null && x.LevelIds.Any());
+
+        RuleFor(x => x.Location)
+            .MaximumLength(100)
+            .Must(id => ValidFreeTextCharactersRegex.IsMatch(id)).WithMessage("Location contains invalid characters.")
+            .When(x => !string.IsNullOrEmpty(x.Location));
+
+        RuleFor(x => x.Distance)
+            .Must(value => value != null && AllowedDistances.Contains(value.Value))
+            .WithMessage("Distance contains invalid characters.")
+            .When(x => x.Distance.HasValue);
+
+        RuleFor(x => x.PageNumber)
+            .GreaterThanOrEqualTo(1).WithMessage("PageNumber must be at least 1.")
+            .When(x => x.PageNumber.HasValue);
+
+        RuleFor(x => x.Sort)
+            .Must(BeAValidSortOption).WithMessage("Invalid sort option.")
+            .When(x => !string.IsNullOrWhiteSpace(x.Sort));
+    }
+
+    private static bool BeAValidSortOption(string? sort)
+    {
+        if (string.IsNullOrWhiteSpace(sort))
+            return false;
+
+        var allowed = Enum.GetNames(typeof(VacancySort))
+            .Select(x => x.ToLowerInvariant())
+            .ToArray();
+
+        return allowed.Contains(sort.ToLowerInvariant());
+    }
 }

--- a/src/SFA.DAS.FAA.Web/Validators/GetSearchResultsRequestValidator.cs
+++ b/src/SFA.DAS.FAA.Web/Validators/GetSearchResultsRequestValidator.cs
@@ -9,7 +9,7 @@ namespace SFA.DAS.FAA.Web.Validators;
 public class GetSearchResultsRequestValidator : AbstractValidator<GetSearchResultsRequest>
 {
     private static readonly int[] AllowedDistances = [2, 5, 10, 15, 20, 30, 40];
-    private static readonly Regex NumericRegex = new(@"^\d+$", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
+    private static readonly Regex NumericRegex = new(@"^\d+$", RegexOptions.Compiled, TimeSpan.FromSeconds(2.0));
 
     public GetSearchResultsRequestValidator()
     {

--- a/src/SFA.DAS.FAA.Web/Validators/GetSearchResultsRequestValidator.cs
+++ b/src/SFA.DAS.FAA.Web/Validators/GetSearchResultsRequestValidator.cs
@@ -9,8 +9,8 @@ namespace SFA.DAS.FAA.Web.Validators;
 public class GetSearchResultsRequestValidator : AbstractValidator<GetSearchResultsRequest>
 {
     private static readonly int[] AllowedDistances = [2, 5, 10, 15, 20, 30, 40];
-    private static readonly Regex NumericRegex = new(@"^\d+$", RegexOptions.Compiled);
-    private static readonly Regex ValidFreeTextCharactersRegex = new(@"^[a-zA-Z0-9\s,'-]*$", RegexOptions.Compiled);
+    private static readonly Regex NumericRegex = new(@"^\d+$", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
+    private static readonly Regex ValidFreeTextCharactersRegex = new(@"^[a-zA-Z0-9\s,'-]*$", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
 
     public GetSearchResultsRequestValidator()
     {
@@ -22,12 +22,12 @@ public class GetSearchResultsRequestValidator : AbstractValidator<GetSearchResul
         RuleForEach(x => x.RouteIds)
             .Must(id => NumericRegex.IsMatch(id)).WithMessage("Each RouteId must be numeric.")
             .MaximumLength(10).WithMessage("RouteId must be at most 10 digits.")
-            .When(x => x.RouteIds != null && x.RouteIds.Any());
+            .When(x => x.RouteIds is {Count: > 0});
 
         RuleForEach(x => x.LevelIds)
             .Must(id => NumericRegex.IsMatch(id)).WithMessage("Each LevelId must be numeric.")
             .MaximumLength(10).WithMessage("LevelId must be at most 10 digits.")
-            .When(x => x.LevelIds != null && x.LevelIds.Any());
+            .When(x => x.LevelIds is { Count: > 0 });
 
         RuleFor(x => x.Location)
             .MaximumLength(100)


### PR DESCRIPTION
✨ Enhance validation and testing for search requests

- Updated `WhenValidatingSearchRequest.cs` to use FluentValidation's test helper.
- Refactored tests to use `MoqInlineAutoData` for improved readability.
- Introduced a constant `PageSize` in `SearchApprenticeshipsController.cs`.
- Enhanced validation rules in `GetSearchResultsRequestValidator.cs`.
- Added checks for numeric values and valid characters in validation logic.

Changes made by Balaji Jambulingam