### PR TITLE
FAI-2406 Update the View application page after submission

### DIFF
--- a/src/SFA.DAS.FAA.Web.UnitTests/Models/EmploymentLocationViewModelTests.cs
+++ b/src/SFA.DAS.FAA.Web.UnitTests/Models/EmploymentLocationViewModelTests.cs
@@ -1,0 +1,79 @@
+using Newtonsoft.Json;
+using SFA.DAS.FAA.Domain.Models;
+using SFA.DAS.FAA.Web.Extensions;
+using SFA.DAS.FAA.Web.Models;
+
+namespace SFA.DAS.FAA.Web.UnitTests.Models
+{
+    [TestFixture]
+    public class EmploymentLocationViewModelTests
+    {
+        [Test]
+        public void ImplicitOperator_ShouldMapProperties_WhenFullAddressIsValidJson()
+        {
+            // Arrange
+            var address = new Address("Line1", "Line2", "Line3", "Line4", "AB12 3CD", 1.23, 4.56);
+            var addressJson = JsonConvert.SerializeObject(address);
+            var dto = new AddressDto
+            {
+                Id = Guid.NewGuid(),
+                FullAddress = addressJson,
+                IsSelected = true,
+                AddressOrder = 2
+            };
+
+            // Act
+            EmploymentLocationViewModel viewModel = dto;
+
+            // Assert
+            viewModel.Id.Should().Be(dto.Id);
+            viewModel.FullAddress.Should().Be(address.ToSingleLineFullAddress());
+            viewModel.IsSelected.Should().BeTrue();
+            viewModel.AddressOrder.Should().Be(dto.AddressOrder);
+        }
+
+        [Test]
+        public void ImplicitOperator_ShouldSetEmploymentAddressToNull_WhenFullAddressIsNullOrWhitespace()
+        {
+            // Arrange
+            var dto = new AddressDto
+            {
+                Id = Guid.NewGuid(),
+                FullAddress = " ",
+                IsSelected = false,
+                AddressOrder = 1
+            };
+
+            // Act
+            EmploymentLocationViewModel viewModel = dto;
+
+            // Assert
+            viewModel.Id.Should().Be(dto.Id);
+            viewModel.FullAddress.Should().BeNullOrEmpty();
+            viewModel.IsSelected.Should().BeFalse();
+            viewModel.AddressOrder.Should().Be(dto.AddressOrder);
+        }
+
+        [Test]
+        public void ImplicitOperator_ShouldSetEmploymentAddressToEmpty_WhenFullAddressIsInvalidJson()
+        {
+            // Arrange
+            var dto = new AddressDto
+            {
+                Id = Guid.NewGuid(),
+                FullAddress = "not a json",
+                IsSelected = true,
+                AddressOrder = 3
+            };
+
+            // Act
+            EmploymentLocationViewModel viewModel = dto;
+
+            // Assert
+            viewModel.Id.Should().Be(dto.Id);
+            viewModel.FullAddress.Should().Be(Address.Empty.ToSingleLineFullAddress());
+            viewModel.IsSelected.Should().BeTrue();
+            viewModel.AddressOrder.Should().Be(dto.AddressOrder);
+        }
+    }
+}

--- a/src/SFA.DAS.FAA.Web/Models/Applications/ApplicationViewModel.cs
+++ b/src/SFA.DAS.FAA.Web/Models/Applications/ApplicationViewModel.cs
@@ -1,8 +1,5 @@
-﻿using Newtonsoft.Json;
-using SFA.DAS.FAA.Application.Queries.Apply.GetApplicationView;
+﻿using SFA.DAS.FAA.Application.Queries.Apply.GetApplicationView;
 using SFA.DAS.FAA.Domain.Enums;
-using SFA.DAS.FAA.Domain.Models;
-using SFA.DAS.FAA.Web.Extensions;
 using SFA.DAS.FAA.Web.Models.Apply;
 using System.Globalization;
 
@@ -68,40 +65,15 @@ public class ApplicationViewModel
 
     public record EmploymentLocationSection
     {
-        public List<AddressDto>? EmploymentAddress { get; init; }
+        public List<EmploymentLocationViewModel>? EmploymentAddress { get; init; }
         public AvailableWhere? EmployerLocationOption { get; set; }
 
         public static implicit operator EmploymentLocationSection?(GetApplicationViewQueryResult.EmploymentLocationSection? source)
         {
             if (source is null) return null;
 
-            if (source?.Addresses == null)
-            {
-                return new EmploymentLocationSection();
-            }
-
             var addresses = source.Addresses
-                .Select(x =>
-                {
-                    Address? employmentAddress;
-                    try
-                    {
-                        employmentAddress = !string.IsNullOrWhiteSpace(x.FullAddress)
-                            ? JsonConvert.DeserializeObject<Address>(x.FullAddress)
-                            : null;
-                    }
-                    catch (JsonException)
-                    {
-                        employmentAddress = null;
-                    }
-                    return new AddressDto
-                    {
-                        Id = x.Id,
-                        EmploymentAddress = employmentAddress,
-                        IsSelected = x.IsSelected,
-                        AddressOrder = x.AddressOrder
-                    };
-                })
+                .Select(x => (EmploymentLocationViewModel)x)
                 .OrderBy(add => add.AddressOrder)
                 .ToList();
 
@@ -110,15 +82,6 @@ public class ApplicationViewModel
                 EmploymentAddress = addresses,
                 EmployerLocationOption = source.EmployerLocationOption,
             };
-        }
-
-        public record AddressDto
-        {
-            public Guid Id { get; init; }
-            public Address? EmploymentAddress { get; init; }
-            public string? FullAddress => EmploymentAddress.ToSingleLineFullAddress();
-            public bool IsSelected { get; init; }
-            public short AddressOrder { get; init; }
         }
     }
 

--- a/src/SFA.DAS.FAA.Web/Models/Apply/AddEmploymentLocationsViewModel.cs
+++ b/src/SFA.DAS.FAA.Web/Models/Apply/AddEmploymentLocationsViewModel.cs
@@ -1,46 +1,17 @@
-using Newtonsoft.Json;
 using SFA.DAS.FAA.Application.Queries.Apply.GetEmploymentLocations;
-using SFA.DAS.FAA.Domain.Models;
-using SFA.DAS.FAA.Web.Extensions;
 
 namespace SFA.DAS.FAA.Web.Models.Apply;
 
 public record AddEmploymentLocationsViewModel
 {
-    public List<AddressDto> Addresses { get; set; } = [];
+    public List<EmploymentLocationViewModel> Addresses { get; init; } = [];
     public Guid ApplicationId { get; set; }
-    public List<Guid>? SelectedAddressIds { get; set; }
+    public List<Guid>? SelectedAddressIds { get; init; }
 
     public static implicit operator AddEmploymentLocationsViewModel(GetEmploymentLocationsQueryResult result)
     {
-        if (result.EmploymentLocation?.Addresses == null)
-        {
-            return new AddEmploymentLocationsViewModel();
-        }
-
         var addresses = result.EmploymentLocation.Addresses
-            .Select(x =>
-            {
-                Address? employmentAddress;
-                try
-                {
-                    employmentAddress = !string.IsNullOrWhiteSpace(x.FullAddress)
-                        ? JsonConvert.DeserializeObject<Address>(x.FullAddress)
-                        : null;
-                }
-                catch (JsonException)
-                {
-                    employmentAddress = Address.Empty;
-                }
-
-                return new AddressDto
-                {
-                    Id = x.Id,
-                    EmploymentAddress = employmentAddress,
-                    IsSelected = x.IsSelected,
-                    AddressOrder = x.AddressOrder
-                };
-            })
+            .Select(x => (EmploymentLocationViewModel)x)
             .OrderBy(add => add.AddressOrder)
             .ToList();
 
@@ -48,14 +19,5 @@ public record AddEmploymentLocationsViewModel
         {
             Addresses = addresses
         };
-    }
-
-    public record AddressDto
-    {
-        public Guid Id { get; init; }
-        public Address? EmploymentAddress { get; init; }
-        public string? FullAddress => EmploymentAddress?.ToSingleLineFullAddress();
-        public bool IsSelected { get; init; }
-        public short AddressOrder { get; init; }
     }
 }

--- a/src/SFA.DAS.FAA.Web/Models/Apply/ApplicationSummaryViewModel.cs
+++ b/src/SFA.DAS.FAA.Web/Models/Apply/ApplicationSummaryViewModel.cs
@@ -223,41 +223,16 @@ public class ApplicationSummaryViewModel
 
     public record EmploymentLocationSection
     {
-        public List<AddressDto>? EmploymentAddress { get; init; }
-        public AvailableWhere? EmployerLocationOption { get; set; }
+        public List<EmploymentLocationViewModel>? EmploymentAddress { get; init; }
+        public AvailableWhere? EmployerLocationOption { get; init; }
         public SectionStatus EmploymentLocationStatus { get; private init; }
 
         public static implicit operator EmploymentLocationSection?(GetApplicationSummaryQueryResult.EmploymentLocationSection? source)
         {
             if (source is null) return null;
 
-            if (source?.Addresses == null)
-            {
-                return new EmploymentLocationSection();
-            }
-
             var addresses = source.Addresses
-                .Select(x =>
-                {
-                    Address? employmentAddress;
-                    try
-                    {
-                        employmentAddress = !string.IsNullOrWhiteSpace(x.FullAddress)
-                            ? JsonConvert.DeserializeObject<Address>(x.FullAddress)
-                            : null;
-                    }
-                    catch (JsonException)
-                    {
-                        employmentAddress = Address.Empty;
-                    }
-                    return new AddressDto
-                    {
-                        Id = x.Id,
-                        EmploymentAddress = employmentAddress,
-                        IsSelected = x.IsSelected,
-                        AddressOrder = x.AddressOrder
-                    };
-                })
+                .Select(x => (EmploymentLocationViewModel)x)
                 .OrderBy(add => add.AddressOrder)
                 .ToList();
 
@@ -267,15 +242,6 @@ public class ApplicationSummaryViewModel
                 EmployerLocationOption = source.EmployerLocationOption,
                 EmploymentLocationStatus = source.EmploymentLocationStatus
             };
-        }
-
-        public record AddressDto
-        {
-            public Guid Id { get; init; }
-            public Address? EmploymentAddress { get; init; }
-            public string? FullAddress => EmploymentAddress?.ToSingleLineFullAddress();
-            public bool IsSelected { get; init; }
-            public short AddressOrder { get; init; }
         }
     }
 

--- a/src/SFA.DAS.FAA.Web/Models/Apply/EmploymentLocationsSummaryViewModel.cs
+++ b/src/SFA.DAS.FAA.Web/Models/Apply/EmploymentLocationsSummaryViewModel.cs
@@ -1,14 +1,11 @@
 using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json;
 using SFA.DAS.FAA.Application.Queries.Apply.GetEmploymentLocations;
-using SFA.DAS.FAA.Domain.Models;
-using SFA.DAS.FAA.Web.Extensions;
 
 namespace SFA.DAS.FAA.Web.Models.Apply;
 
 public record EmploymentLocationsSummaryViewModel
 {
-    public List<AddressDto> Addresses { get; set; } = [];
+    public List<EmploymentLocationViewModel> Addresses { get; init; } = [];
     public Guid ApplicationId { get; set; }
     public string? BackLinkUrl { get; set; }
 
@@ -17,34 +14,8 @@ public record EmploymentLocationsSummaryViewModel
 
     public static implicit operator EmploymentLocationsSummaryViewModel(GetEmploymentLocationsQueryResult result)
     {
-        if (result?.EmploymentLocation?.Addresses == null)
-        {
-            return new EmploymentLocationsSummaryViewModel();
-        }
-
         var addresses = result.EmploymentLocation.Addresses
-            .Select(x =>
-            {
-                Address? employmentAddress;
-                try
-                {
-                    employmentAddress = !string.IsNullOrWhiteSpace(x.FullAddress)
-                        ? JsonConvert.DeserializeObject<Address>(x.FullAddress)
-                        : null;
-                }
-                catch (JsonException)
-                {
-                    employmentAddress = Address.Empty;
-                }
-
-                return new AddressDto
-                {
-                    Id = x.Id,
-                    EmploymentAddress = employmentAddress,
-                    IsSelected = x.IsSelected,
-                    AddressOrder = x.AddressOrder
-                };
-            })
+            .Select(x => (EmploymentLocationViewModel)x)
             .OrderBy(add => add.AddressOrder)
             .ToList();
 
@@ -52,14 +23,5 @@ public record EmploymentLocationsSummaryViewModel
         {
             Addresses = addresses
         };
-    }
-
-    public record AddressDto
-    {
-        public Guid Id { get; init; }
-        public Address? EmploymentAddress { get; init; }
-        public string? FullAddress => EmploymentAddress?.ToSingleLineFullAddress();
-        public bool IsSelected { get; init; }
-        public short AddressOrder { get; init; }
     }
 }

--- a/src/SFA.DAS.FAA.Web/Models/EmploymentLocationViewModel.cs
+++ b/src/SFA.DAS.FAA.Web/Models/EmploymentLocationViewModel.cs
@@ -1,0 +1,38 @@
+﻿using Newtonsoft.Json;
+using SFA.DAS.FAA.Domain.Models;
+using SFA.DAS.FAA.Web.Extensions;
+
+namespace SFA.DAS.FAA.Web.Models
+{
+    public record EmploymentLocationViewModel
+    {
+        public Guid Id { get; init; }
+        private Address? EmploymentAddress { get; init; }
+        public string? FullAddress => EmploymentAddress?.ToSingleLineFullAddress();
+        public bool IsSelected { get; init; }
+        public short AddressOrder { get; init; }
+
+        public static implicit operator EmploymentLocationViewModel(AddressDto addressDto)
+        {
+            Address? employmentAddress;
+            try
+            {
+                employmentAddress = !string.IsNullOrWhiteSpace(addressDto.FullAddress)
+                    ? JsonConvert.DeserializeObject<Address>(addressDto.FullAddress)
+                    : null;
+            }
+            catch (JsonException)
+            {
+                employmentAddress = Address.Empty;
+            }
+
+            return new EmploymentLocationViewModel
+            {
+                Id = addressDto.Id,
+                EmploymentAddress = employmentAddress,
+                IsSelected = addressDto.IsSelected,
+                AddressOrder = addressDto.AddressOrder
+            };
+        }
+    }
+}

--- a/src/SFA.DAS.FAA.Web/Views/Applications/ViewApplication.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/Applications/ViewApplication.cshtml
@@ -6,9 +6,9 @@
     ViewData["Title"] = $"Your application to {@Model.VacancyDetails.EmployerName} – Find an apprenticeship – GOV.UK";
     var tagName = Model.ApplicationStatus switch
     {
-        ApplicationStatus.Successful => ApplicationsTab.Successful.ToString(),
-        ApplicationStatus.Unsuccessful => ApplicationsTab.Unsuccessful.ToString(),
-        _ => ApplicationsTab.Submitted.ToString()
+        ApplicationStatus.Successful => nameof(ApplicationsTab.Successful),
+        ApplicationStatus.Unsuccessful => nameof(ApplicationsTab.Unsuccessful),
+        _ => nameof(ApplicationsTab.Submitted)
     };
 }
 @section BackLink {

--- a/src/SFA.DAS.FAA.Web/Views/Apply/EmploymentLocations/List.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/Apply/EmploymentLocations/List.cshtml
@@ -1,5 +1,4 @@
 @using SFA.DAS.FAA.Web.Infrastructure
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model SFA.DAS.FAA.Web.Models.Apply.AddEmploymentLocationsViewModel
 @{
     ViewData["Title"] = "Where do you want to apply for? – Find an apprenticeship – GOV.UK";


### PR DESCRIPTION
✨ Refactor employment location handling with new view model

- Introduced `EmploymentLocationViewModel` to replace `AddressDto`.
- Updated view models to use `List<EmploymentLocationViewModel>`.
- Modified implicit operator methods for proper JSON deserialization.
- Added unit tests for `EmploymentLocationViewModel` mapping scenarios.
- Made minor adjustments in view files for application status handling.

Changes made by Balaji Jambulingam