### PR TITLE
FAI-2472 View an application foundation apprenticeships

### DIFF
--- a/src/SFA.DAS.FAA.Application/Queries/Apply/GetApplicationView/GetApplicationViewQuery.cs
+++ b/src/SFA.DAS.FAA.Application/Queries/Apply/GetApplicationView/GetApplicationViewQuery.cs
@@ -2,9 +2,9 @@
 
 namespace SFA.DAS.FAA.Application.Queries.Apply.GetApplicationView
 {
-    public class GetApplicationViewQuery : IRequest<GetApplicationViewQueryResult>
+    public record GetApplicationViewQuery : IRequest<GetApplicationViewQueryResult>
     {
-        public Guid ApplicationId { get; set; }
-        public Guid? CandidateId { get; set; }
+        public Guid ApplicationId { get; init; }
+        public Guid? CandidateId { get; init; }
     }
 }

--- a/src/SFA.DAS.FAA.Application/Queries/Apply/GetApplicationView/GetApplicationViewQueryResult.cs
+++ b/src/SFA.DAS.FAA.Application/Queries/Apply/GetApplicationView/GetApplicationViewQueryResult.cs
@@ -18,6 +18,7 @@ namespace SFA.DAS.FAA.Application.Queries.Apply.GetApplicationView
         public ApplicationStatus ApplicationStatus { get; set; }
         public DateTime? WithdrawnDate { get; set; }
         public DateTime? MigrationDate { get; set; }
+        public ApprenticeshipTypes? ApprenticeshipType { get; init; } = ApprenticeshipTypes.Standard;
 
         public static implicit operator GetApplicationViewQueryResult(GetApplicationViewApiResponse source)
         {
@@ -37,6 +38,7 @@ namespace SFA.DAS.FAA.Application.Queries.Apply.GetApplicationView
                 ApplicationStatus = applicationStatus,
                 WithdrawnDate = source.WithdrawnDate,
                 MigrationDate = source.MigrationDate,
+                ApprenticeshipType = source.ApprenticeshipType,
             };
         }
 

--- a/src/SFA.DAS.FAA.ApplicationUnitTests/Queries/Applications/WhenHandlingGetApplicationViewQueryHandler.cs
+++ b/src/SFA.DAS.FAA.ApplicationUnitTests/Queries/Applications/WhenHandlingGetApplicationViewQueryHandler.cs
@@ -1,12 +1,7 @@
-﻿using AutoFixture.NUnit3;
-using FluentAssertions;
-using Moq;
-using NUnit.Framework;
-using SFA.DAS.FAA.Application.Queries.Apply.GetApplicationView;
+﻿using SFA.DAS.FAA.Application.Queries.Apply.GetApplicationView;
 using SFA.DAS.FAA.Domain.Apply.GetApplicationView;
 using SFA.DAS.FAA.Domain.Enums;
 using SFA.DAS.FAA.Domain.Interfaces;
-using SFA.DAS.Testing.AutoFixture;
 
 namespace SFA.DAS.FAA.Application.UnitTests.Queries.Applications
 {
@@ -33,10 +28,11 @@ namespace SFA.DAS.FAA.Application.UnitTests.Queries.Applications
             var result = await handler.Handle(query, CancellationToken.None);
 
             // Assert
-            result.Should().BeEquivalentTo(apiResponse, options=> options.Excluding(c=>c.ApplicationStatus));
+            result.Should().BeEquivalentTo(apiResponse, options => options.Excluding(c => c.ApplicationStatus));
             result.ApplicationStatus.Should().Be(ApplicationStatus.Withdrawn);
             result.WithdrawnDate.Should().Be(apiResponse.WithdrawnDate);
             result.MigrationDate.Should().Be(apiResponse.MigrationDate);
+            result.ApprenticeshipType.Should().Be(apiResponse.ApprenticeshipType);
         }
     }
 }

--- a/src/SFA.DAS.FAA.Domain/Apply/GetApplicationView/GetApplicationViewApiResponse.cs
+++ b/src/SFA.DAS.FAA.Domain/Apply/GetApplicationView/GetApplicationViewApiResponse.cs
@@ -1,4 +1,6 @@
-﻿namespace SFA.DAS.FAA.Domain.Apply.GetApplicationView
+﻿using SFA.DAS.FAA.Domain.Enums;
+
+namespace SFA.DAS.FAA.Domain.Apply.GetApplicationView
 {
     public class GetApplicationViewApiResponse
     {
@@ -15,6 +17,7 @@
         public string ApplicationStatus { get; set; }
         public DateTime? WithdrawnDate { get; set; }
         public DateTime? MigrationDate { get; set; }
+        public ApprenticeshipTypes? ApprenticeshipType { get; set; } = ApprenticeshipTypes.Standard;
 
         public record VacancyDetailsSection
         {

--- a/src/SFA.DAS.FAA.Web.UnitTests/Controllers/Applications/WhenGettingApplicationView.cs
+++ b/src/SFA.DAS.FAA.Web.UnitTests/Controllers/Applications/WhenGettingApplicationView.cs
@@ -1,19 +1,14 @@
-﻿using AutoFixture.NUnit3;
-using FluentAssertions;
-using FluentAssertions.Execution;
-using MediatR;
+﻿using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Routing;
-using Moq;
-using NUnit.Framework;
 using SFA.DAS.FAA.Application.Queries.Apply.GetApplicationView;
 using SFA.DAS.FAA.Web.AppStart;
 using SFA.DAS.FAA.Web.Controllers;
 using SFA.DAS.FAA.Web.Models.Applications;
 using SFA.DAS.FAT.Domain.Interfaces;
-using SFA.DAS.Testing.AutoFixture;
 using System.Security.Claims;
+using SFA.DAS.FAA.Domain.Enums;
 
 namespace SFA.DAS.FAA.Web.UnitTests.Controllers.Applications
 {
@@ -41,10 +36,9 @@ namespace SFA.DAS.FAA.Web.UnitTests.Controllers.Applications
                     c.CandidateId.Equals(candidateId)), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(queryResult);
 
-            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
-            {
-                new(CustomClaims.CandidateId, candidateId.ToString()),
-            }));
+            var user = new ClaimsPrincipal(new ClaimsIdentity([
+                new(CustomClaims.CandidateId, candidateId.ToString())
+            ]));
             controller.ControllerContext = new ControllerContext
             {
                 HttpContext = new DefaultHttpContext { User = user }
@@ -59,6 +53,8 @@ namespace SFA.DAS.FAA.Web.UnitTests.Controllers.Applications
                 actualModel!.ApplicationId.Should().Be(applicationId);
                 actualModel.WithdrawnDate.Should().Be(queryResult.WithdrawnDate);
                 actualModel.MigrationDate.Should().Be(queryResult.MigrationDate);
+                actualModel.ShowFoundationTag.Should()
+                    .Be(queryResult.ApprenticeshipType == ApprenticeshipTypes.Foundation);
             }
         }
     }

--- a/src/SFA.DAS.FAA.Web/Models/Applications/ApplicationViewModel.cs
+++ b/src/SFA.DAS.FAA.Web/Models/Applications/ApplicationViewModel.cs
@@ -26,6 +26,8 @@ public class ApplicationViewModel
             ApplicationStatus = source.ApplicationStatus,
             WithdrawnDate = source.WithdrawnDate,
             MigrationDate = source.MigrationDate,
+            ApprenticeshipType = source.ApprenticeshipType,
+
         };
     }
 
@@ -44,6 +46,9 @@ public class ApplicationViewModel
     public WhatIsYourInterestSection WhatIsYourInterest { get; init; } = new();
     public AboutYouSection AboutYou { get; init; } = new();
     public VacancyDetailsSection VacancyDetails { get; init; } = new();
+
+    private ApprenticeshipTypes? ApprenticeshipType { get; init; } = ApprenticeshipTypes.Standard;
+    public bool ShowFoundationTag => ApprenticeshipType == ApprenticeshipTypes.Foundation;
 
     public record VacancyDetailsSection
     {

--- a/src/SFA.DAS.FAA.Web/Views/Applications/ViewApplication.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/Applications/ViewApplication.cshtml
@@ -6,9 +6,9 @@
     ViewData["Title"] = $"Your application to {@Model.VacancyDetails.EmployerName} – Find an apprenticeship – GOV.UK";
     var tagName = Model.ApplicationStatus switch
     {
-        ApplicationStatus.Successful => ApplicationsTab.Successful.ToString(),
-        ApplicationStatus.Unsuccessful => ApplicationsTab.Unsuccessful.ToString(),
-        _ => ApplicationsTab.Submitted.ToString()
+        ApplicationStatus.Successful => nameof(ApplicationsTab.Successful),
+        ApplicationStatus.Unsuccessful => nameof(ApplicationsTab.Unsuccessful),
+        _ => nameof(ApplicationsTab.Submitted)
     };
 }
 @section BackLink {
@@ -35,6 +35,7 @@
 }
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+        <govuk-tag-foundation asp-show="@Model.ShowFoundationTag" class="govuk-!-margin-bottom-4"></govuk-tag-foundation>
         <h1 class="govuk-heading-l">Your application</h1>
         <div class="govuk-body">
             @Model.VacancyDetails.Title at @Model.VacancyDetails.EmployerName.


### PR DESCRIPTION
- Convert `GetApplicationViewQuery` to a record with `init` properties.
- Add `ApprenticeshipType` to `GetApplicationViewQueryResult` and API response.
- Update tests to remove unnecessary usings and include new properties.
- Enhance `ApplicationViewModel` with `ApprenticeshipType` and a computed tag.
- Modify Razor view to conditionally render foundation tag based on new property.

Changes made by Balaji Jambulingam