### PR TITLE
FAI-2795 Search and filters broken on FAA search results page

### DIFF
--- a/src/SFA.DAS.FAA.Web/Controllers/SearchApprenticeshipsController.cs
+++ b/src/SFA.DAS.FAA.Web/Controllers/SearchApprenticeshipsController.cs
@@ -175,8 +175,8 @@ public class SearchApprenticeshipsController(
         [FromServices] IValidator<GetSearchResultsRequest> validator,
         [FromQuery] GetSearchResultsRequest request)
     {
-        await validator.ValidateAndUpdateModelStateAsync(request, ModelState);
-        if (!ModelState.IsValid)
+        var validationResult = await validator.ValidateAndUpdateModelStateAsync(request, ModelState);
+        if (!validationResult.IsValid)
         {
             return View(new SearchResultsViewModel
             {

--- a/src/SFA.DAS.FAA.Web/Program.cs
+++ b/src/SFA.DAS.FAA.Web/Program.cs
@@ -14,7 +14,7 @@ var rootConfiguration = builder.Configuration.LoadConfiguration(isIntegrationTes
 builder.Services
     .AddOptions()
     .AddMemoryCache()
-    .AddValidatorsFromAssembly(typeof(Program).Assembly, includeInternalTypes: true)
+    .AddValidatorsFromAssembly(typeof(Program).Assembly)
     .AddControllers(options =>
     {
         options.ModelBinderProviders.Insert(0, new MonthYearDateModelBinderProvider());

--- a/src/SFA.DAS.FAA.Web/SFA.DAS.FAA.Web.csproj
+++ b/src/SFA.DAS.FAA.Web/SFA.DAS.FAA.Web.csproj
@@ -59,5 +59,8 @@
   <Target Name="NpmRunBuild" DependsOnTargets="NpmInstall" BeforeTargets="BeforeBuild">
     <Exec Command="npm run build" />
   </Target>
-
+    
+    <ItemGroup>
+        <InternalsVisibleTo Include="SFA.DAS.FAA.Web.UnitTests" />
+    </ItemGroup>
 </Project>

--- a/src/SFA.DAS.FAA.Web/Validators/AddQualificationViewModelValidator.cs
+++ b/src/SFA.DAS.FAA.Web/Validators/AddQualificationViewModelValidator.cs
@@ -11,14 +11,13 @@ public class AddQualificationViewModelValidator : AbstractValidator<AddQualifica
         RuleForEach(x => x.Subjects).SetValidator(x=> new SubjectViewModelValidator(new QualificationDisplayTypeViewModel(x.QualificationType,x.QualificationReferenceId)));
     }
 }
-public class SubjectViewModelValidator : AbstractValidator<SubjectViewModel>
+internal class SubjectViewModelValidator : AbstractValidator<SubjectViewModel>
 {
     public SubjectViewModelValidator(QualificationDisplayTypeViewModel model)
     {
         var isApprenticeship = model.GroupTitle.Equals("apprenticeship", StringComparison.CurrentCultureIgnoreCase);
         var isDegree = model.GroupTitle.Equals("degree", StringComparison.CurrentCultureIgnoreCase);
         var isOther = model.GroupTitle.Equals("Other", StringComparison.CurrentCultureIgnoreCase);
-        
         
         if (!isApprenticeship)
         {


### PR DESCRIPTION
Two changes:

1. The registration code caused problems due to a non-standard validator declaration, I've change the code to only register public validators and made the problem one internal - it's only referenced by another validator and not used on its own
2. Fixed the search results action that was checking the ModelState which _always_ invalid.