### PR TITLE
FAI-3417 FAA Leo Data

### DIFF
--- a/src/SFA.DAS.FAA.Web/SFA.DAS.FAA.Web.csproj
+++ b/src/SFA.DAS.FAA.Web/SFA.DAS.FAA.Web.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.3" />
     <PackageReference Include="MediatR" Version="12.5.0" />
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="17.1.165" />
-	<PackageReference Include="SFA.DAS.GovUK.Auth" Version="17.1.190" />
+	  <PackageReference Include="SFA.DAS.GovUK.Auth" Version="17.1.190" />
     <PackageReference Include="SFA.DAS.InputValidation" Version="17.1.100" />
     <PackageReference Include="StackExchange.Redis" Version="2.11.8" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.3" />
@@ -29,6 +29,7 @@
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.3" />
+    <PackageReference Include="WebEssentials.AspNetCore.CdnTagHelpers" Version="1.0.21" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.FAA.Web/SFA.DAS.FAA.Web.csproj
+++ b/src/SFA.DAS.FAA.Web/SFA.DAS.FAA.Web.csproj
@@ -29,7 +29,6 @@
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.3" />
-    <PackageReference Include="WebEssentials.AspNetCore.CdnTagHelpers" Version="1.0.21" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.FAA.Web/Views/Apply/DisabilityConfident/Index.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/Apply/DisabilityConfident/Index.cshtml
@@ -1,6 +1,4 @@
 ﻿@using SFA.DAS.FAA.Web.Infrastructure
-@using WebEssentials.AspNetCore.CdnTagHelpers
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model SFA.DAS.FAA.Web.Models.Apply.DisabilityConfidentViewModel
 @{
     ViewData["Title"] = "Disability Confident scheme – Find an apprenticeship – GOV.UK";

--- a/src/SFA.DAS.FAA.Web/Views/SearchApprenticeships/Index.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/SearchApprenticeships/Index.cshtml
@@ -1,6 +1,5 @@
 ﻿@using SFA.DAS.FAA.Web.Infrastructure
 @using SFA.DAS.FAA.Web.Extensions
-@using SFA.DAS.FAA.Web.TagHelpers
 @model SFA.DAS.FAA.Web.Models.SearchResults.SearchApprenticeshipsViewModel
 @{
     ViewData["Title"] = "Search apprenticeship – Find an apprenticeship – GOV.UK";
@@ -18,15 +17,6 @@
     {
         <partial name="_NationalApprenticeshipWeekBanner" />
     }
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <govuk-banner style="@BannerStyle.Important">
-                <govuk-banner-heading>Your future pay as an apprentice.</govuk-banner-heading>
-                <a class="govuk-link" href="https://www.apprenticeships.gov.uk/apprentices/apprentice-pay-and-future-salary">Find out what you could earn</a> after you complete your apprenticeship.
-            </govuk-banner>
-        </div>
-    </div>
-    
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             @if (!ViewData.ModelState.IsValid)

--- a/src/SFA.DAS.FAA.Web/Views/Shared/_GoogleAnalyticsPartial.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/Shared/_GoogleAnalyticsPartial.cshtml
@@ -1,5 +1,4 @@
 ﻿@using SFA.DAS.FAA.Web.Infrastructure
-@using WebEssentials.AspNetCore.CdnTagHelpers
 @if (Context.Request.Cookies.ContainsKey(CookieKeys.AnalyticsConsent) 
      && Context.Request.Cookies.TryGetValue(CookieKeys.AnalyticsConsent,
          out var isConsentGiven)

--- a/src/SFA.DAS.FAA.Web/Views/Shared/_GoogleMapsPartial.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/Shared/_GoogleMapsPartial.cshtml
@@ -2,7 +2,6 @@
 @using SFA.DAS.FAA.Web.Infrastructure
 @using SFA.DAS.FAA.Domain.Configuration
 @inject IOptions<FindAnApprenticeship> Configuration
-@using WebEssentials.AspNetCore.CdnTagHelpers
 @if (Context.Request.Cookies.ContainsKey(CookieKeys.FunctionalConsent) && Context.Request.Cookies.TryGetValue(CookieKeys.FunctionalConsent, out var isConsentGiven) && bool.TryParse(isConsentGiven, out var consentResult) && consentResult)
 {
     <script>(g => { var h, a, k, p = "The Google Maps JavaScript API", c = "google", l = "importLibrary", q = "__ib__", m = document, b = window; b = b[c] || (b[c] = {}); var d = b.maps || (b.maps = {}), r = new Set, e = new URLSearchParams, u = () => h || (h = new Promise(async (f, n) => { await (a = m.createElement("script")); e.set("libraries", [...r] + ""); for (k in g) e.set(k.replace(/[A-Z]/g, t => "_" + t[0].toLowerCase()), g[k]); e.set("callback", c + ".maps." + q); a.src = `https://maps.${c}apis.com/maps/api/js?` + e; d[q] = f; a.onerror = () => h = n(Error(p + " could not load.")); a.nonce = m.querySelector("script[nonce]")?.nonce || ""; m.head.append(a) })); d[l] ? console.warn(p + " only loads once. Ignoring:", g) : d[l] = (f, ...n) => r.add(f) && u().then(() => d[l](f, ...n)) })

--- a/src/SFA.DAS.FAA.Web/Views/Shared/_Layout.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/Shared/_Layout.cshtml
@@ -1,6 +1,4 @@
 @using SFA.DAS.FAA.Web.Infrastructure
-@using WebEssentials.AspNetCore.CdnTagHelpers
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 <!DOCTYPE html>
 <html lang="en" class="govuk-template govuk-template--rebranded faa-template">
 <head>

--- a/src/SFA.DAS.FAA.Web/Views/Shared/_Layout.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/Shared/_Layout.cshtml
@@ -1,5 +1,6 @@
 @using SFA.DAS.FAA.Web.Infrastructure
 @inject Microsoft.ApplicationInsights.AspNetCore.JavaScriptSnippet JavaScriptSnippet
+@inject IConfiguration Configuration
 <!DOCTYPE html>
 <html lang="en" class="govuk-template govuk-template--rebranded faa-template">
 <head>

--- a/src/SFA.DAS.FAA.Web/Views/Shared/_Layout.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/Shared/_Layout.cshtml
@@ -1,4 +1,5 @@
 @using SFA.DAS.FAA.Web.Infrastructure
+@inject Microsoft.ApplicationInsights.AspNetCore.JavaScriptSnippet JavaScriptSnippet
 <!DOCTYPE html>
 <html lang="en" class="govuk-template govuk-template--rebranded faa-template">
 <head>

--- a/src/SFA.DAS.FAA.Web/Views/Vacancies/_RaaVacancy.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/Vacancies/_RaaVacancy.cshtml
@@ -570,7 +570,7 @@ else
             </section>
             <section class="faa-vacancy__section" id="after">
                 <h2 class="govuk-heading-m">After this apprenticeship</h2>
-                <p class="govuk-body">
+                    <p class="govuk-body das-!-color-dark-grey">
                     Your earnings can increase over time with an apprenticeship. <a href="https://www.apprenticeships.gov.uk/apprentices/apprentice-pay-and-future-salary" class="govuk-link govuk-link--no-visited-state" target="_blank">Find out about potential future pay (opens in new tab)</a>
                 </p>
                 <p>

--- a/src/SFA.DAS.FAA.Web/Views/Vacancies/_RaaVacancy.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/Vacancies/_RaaVacancy.cshtml
@@ -571,7 +571,7 @@ else
             <section class="faa-vacancy__section" id="after">
                 <h2 class="govuk-heading-m">After this apprenticeship</h2>
                     <p class="govuk-body das-!-color-dark-grey">
-                    Your earnings can increase over time with an apprenticeship. <a href="https://www.apprenticeships.gov.uk/apprentices/apprentice-pay-and-future-salary" class="govuk-link govuk-link--no-visited-state" target="_blank">Find out about potential future pay (opens in new tab)</a>
+                    Your earnings can increase over time with an apprenticeship. <a href="https://www.apprenticeships.gov.uk/apprentices/apprentice-pay-and-future-salary" class="govuk-link govuk-link--no-visited-state" target="_blank">Find out about potential future pay (opens in new tab).</a>
                 </p>
                 <p>
                     @Html.Raw(Model.OutcomeDescription)

--- a/src/SFA.DAS.FAA.Web/Views/Vacancies/_RaaVacancy.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/Vacancies/_RaaVacancy.cshtml
@@ -570,6 +570,9 @@ else
             </section>
             <section class="faa-vacancy__section" id="after">
                 <h2 class="govuk-heading-m">After this apprenticeship</h2>
+                <p class="govuk-body">
+                    Your earnings can increase over time with an apprenticeship. <a href="https://www.apprenticeships.gov.uk/apprentices/apprentice-pay-and-future-salary" class="govuk-link govuk-link--no-visited-state" target="_blank">Find out about potential future pay (opens in new tab)</a>
+                </p>
                 <p>
                     @Html.Raw(Model.OutcomeDescription)
                 </p>

--- a/src/SFA.DAS.FAA.Web/Views/_ViewImports.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/_ViewImports.cshtml
@@ -1,8 +1,7 @@
 ﻿@using Microsoft.Extensions.Configuration
 @inject IConfiguration Configuration
+@inject Microsoft.ApplicationInsights.AspNetCore.JavaScriptSnippet JavaScriptSnippet
 
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, WebEssentials.AspNetCore.CdnTagHelpers
-<PackageReference Include="WebEssentials.AspNetCore.CdnTagHelpers" Version="1.0.21" />
-@inject Microsoft.ApplicationInsights.AspNetCore.JavaScriptSnippet JavaScriptSnippet
 @addTagHelper *, SFA.DAS.FAA.Web

--- a/src/SFA.DAS.FAA.Web/Views/_ViewImports.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/_ViewImports.cshtml
@@ -1,7 +1,6 @@
 ﻿@using Microsoft.Extensions.Configuration
 @inject IConfiguration Configuration
-@inject Microsoft.ApplicationInsights.AspNetCore.JavaScriptSnippet JavaScriptSnippet
-
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, WebEssentials.AspNetCore.CdnTagHelpers
 @addTagHelper *, SFA.DAS.FAA.Web
+@addTagHelper *, Microsoft.ApplicationInsights.AspNetCore 

--- a/src/SFA.DAS.FAA.Web/Views/_ViewImports.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/_ViewImports.cshtml
@@ -1,5 +1,4 @@
 ﻿@using Microsoft.Extensions.Configuration
-@inject IConfiguration Configuration
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, WebEssentials.AspNetCore.CdnTagHelpers
 @addTagHelper *, SFA.DAS.FAA.Web


### PR DESCRIPTION
refactor: remove banner and relocate pay info link

Removed the apprenticeship pay banner from the homepage and relocated the information to the "After this apprenticeship" section in `_RaaVacancy.cshtml`. This improves contextual relevance for users. Also removed an unused `@using` directive from `Index.cshtml`.