### PR TITLE
FAI-3416 Update Apprenticeship Type Hint Text on FAA Results Page

### DIFF
--- a/src/SFA.DAS.FAA.Web/Controllers/SearchApprenticeshipsController.cs
+++ b/src/SFA.DAS.FAA.Web/Controllers/SearchApprenticeshipsController.cs
@@ -274,7 +274,7 @@ public class SearchApprenticeshipsController(
         List<ApprenticeshipTypesViewModel> apprenticeshipTypesModels = [
             new()
             {
-                HintText = "Introductory apprenticeships for young people, level 2",
+                HintText = "Introductory apprenticeships, level 2",
                 Id = 1,
                 Name = "Foundation apprenticeship",
                 Selected = request.ApprenticeshipTypes?.Contains(ApprenticeshipTypes.Foundation) ?? false,
@@ -282,7 +282,7 @@ public class SearchApprenticeshipsController(
             },
             new()
             {
-                HintText = "Apprenticeships that qualify you for a job, levels 2 to 7",
+                HintText = "Qualifications from levels 2 to 7",
                 Id = 2,
                 Name = "Apprenticeship",
                 Selected = request.ApprenticeshipTypes?.Contains(ApprenticeshipTypes.Standard) ?? false,


### PR DESCRIPTION
Update apprenticeship type hint texts for clarity

Revised the hint text for "Foundation apprenticeship" to remove the reference to "young people" and clarified the level. Updated the "Apprenticeship" hint to focus on qualification levels rather than job qualifications.