### PR TITLE
FAI-3451 Invalid formatting being allowed from recruit to FAA causing styling issue

### DIFF
--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -29,7 +29,7 @@ jobs:
     inputs:
       command: build
       projects: src/SFA.DAS.FAA.Web.AcceptanceTests/SFA.DAS.FAA.Web.AcceptanceTests.csproj
-      arguments: '--configuration ${{ parameters.BuildConfiguration }} --output $(build.artifactstagingdirectory)/acceptance-tests'
+      arguments: '--configuration ${{ parameters.BuildConfiguration }} --no-restore --output $(build.artifactstagingdirectory)/acceptance-tests'
 
   - task: DotNetCoreCLI@2
     displayName: Publish WebAcceptanceTests
@@ -37,7 +37,7 @@ jobs:
       command: publish
       publishWebProjects: false
       projects: src/SFA.DAS.FAA.Web.AcceptanceTests/SFA.DAS.FAA.Web.AcceptanceTests.csproj
-      arguments: '--configuration ${{ parameters.BuildConfiguration }} -o $(build.artifactstagingdirectory)/acceptance-tests/output'
+      arguments: '--configuration ${{ parameters.BuildConfiguration }} --no-restore -o $(build.artifactstagingdirectory)/acceptance-tests/output'
 
   - task: CopyFiles@2
     displayName: Copy Files to $(build.artifactstagingdirectory)/publish

--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -22,7 +22,6 @@ jobs:
     displayName: Publish WebAcceptanceTests
     inputs:
       command: publish
-      publishWebProjects: false
       projects: src/SFA.DAS.FAA.Web.AcceptanceTests/SFA.DAS.FAA.Web.AcceptanceTests.csproj
       arguments: '--configuration ${{ parameters.BuildConfiguration }} -o $(build.artifactstagingdirectory)/acceptance-tests/output'
 

--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -5,7 +5,7 @@ parameters:
 jobs:
 - job: CodeBuild
   pool:
-    name: DAS - Continuous Integration Agents
+    vmImage: ubuntu-22.04
   workspace:
     clean: all
   variables:

--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -19,19 +19,6 @@ jobs:
       ContinueOnVulnerablePackageScanError: true
 
   - task: DotNetCoreCLI@2
-    displayName: Restore Dependencies for WebAcceptanceTests
-    inputs:
-      command: restore
-      projects: src/SFA.DAS.FAA.Web.AcceptanceTests/SFA.DAS.FAA.Web.AcceptanceTests.csproj
-
-  - task: DotNetCoreCLI@2
-    displayName: Build WebAcceptanceTests
-    inputs:
-      command: build
-      projects: src/SFA.DAS.FAA.Web.AcceptanceTests/SFA.DAS.FAA.Web.AcceptanceTests.csproj
-      arguments: '--configuration ${{ parameters.BuildConfiguration }} --no-restore --output $(build.artifactstagingdirectory)/acceptance-tests'
-
-  - task: DotNetCoreCLI@2
     displayName: Publish WebAcceptanceTests
     inputs:
       command: publish

--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -19,6 +19,19 @@ jobs:
       ContinueOnVulnerablePackageScanError: true
 
   - task: DotNetCoreCLI@2
+    displayName: Restore Dependencies for WebAcceptanceTests
+    inputs:
+      command: restore
+      projects: src/SFA.DAS.FAA.Web.AcceptanceTests/SFA.DAS.FAA.Web.AcceptanceTests.csproj
+
+  - task: DotNetCoreCLI@2
+    displayName: Build WebAcceptanceTests
+    inputs:
+      command: build
+      projects: src/SFA.DAS.FAA.Web.AcceptanceTests/SFA.DAS.FAA.Web.AcceptanceTests.csproj
+      arguments: '--configuration ${{ parameters.BuildConfiguration }} --output $(build.artifactstagingdirectory)/acceptance-tests'
+
+  - task: DotNetCoreCLI@2
     displayName: Publish WebAcceptanceTests
     inputs:
       command: publish

--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -5,7 +5,7 @@ parameters:
 jobs:
 - job: CodeBuild
   pool:
-    vmImage: ubuntu-22.04
+    vmImage: ubuntu-24.04
   workspace:
     clean: all
   variables:

--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -35,6 +35,7 @@ jobs:
     displayName: Publish WebAcceptanceTests
     inputs:
       command: publish
+      publishWebProjects: false
       projects: src/SFA.DAS.FAA.Web.AcceptanceTests/SFA.DAS.FAA.Web.AcceptanceTests.csproj
       arguments: '--configuration ${{ parameters.BuildConfiguration }} -o $(build.artifactstagingdirectory)/acceptance-tests/output'
 

--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -24,7 +24,7 @@ jobs:
       command: publish
       publishWebProjects: false
       projects: src/SFA.DAS.FAA.Web.AcceptanceTests/SFA.DAS.FAA.Web.AcceptanceTests.csproj
-      arguments: '--configuration ${{ parameters.BuildConfiguration }} --no-restore -o $(build.artifactstagingdirectory)/acceptance-tests/output'
+      arguments: '--configuration ${{ parameters.BuildConfiguration }} -o $(build.artifactstagingdirectory)/acceptance-tests/output'
 
   - task: CopyFiles@2
     displayName: Copy Files to $(build.artifactstagingdirectory)/publish

--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -5,9 +5,9 @@ parameters:
 jobs:
 - job: CodeBuild
   pool:
-    pool: ubuntu-22.04
-    workspace:
-      clean: all
+    name: DAS - Continuous Integration Agents
+  workspace:
+    clean: all
   variables:
   - group: BUILD Management Resources
 

--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -5,7 +5,7 @@ parameters:
 jobs:
 - job: CodeBuild
   pool:
-    name: DAS - Continuous Integration Agents
+    pool: ubuntu-22.04
     workspace:
       clean: all
   variables:

--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -6,8 +6,8 @@ jobs:
 - job: CodeBuild
   pool:
     name: DAS - Continuous Integration Agents
-  workspace:
-    clean: all
+    workspace:
+      clean: all
   variables:
   - group: BUILD Management Resources
 

--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -5,8 +5,7 @@ parameters:
 jobs:
 - job: CodeBuild
   pool:
-    name: DAS - Continuous Integration Beta
-    demands: Agent.OS -equals Linux
+    name: DAS - Continuous Integration Agents
   workspace:
     clean: all
   variables:

--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -5,7 +5,8 @@ parameters:
 jobs:
 - job: CodeBuild
   pool:
-    vmImage: ubuntu-24.04
+    name: DAS - Continuous Integration Beta
+    demands: Agent.OS -equals Linux
   workspace:
     clean: all
   variables:

--- a/src/SFA.DAS.FAA.Web.UnitTests/TagHelpers/HtmlContentRendererTagHelperTests.cs
+++ b/src/SFA.DAS.FAA.Web.UnitTests/TagHelpers/HtmlContentRendererTagHelperTests.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+using SFA.DAS.FAA.Web.TagHelpers;
+
+namespace SFA.DAS.FAA.Web.UnitTests.TagHelpers;
+
+[TestFixture]
+internal class HtmlContentRendererTagHelperTests : TagHelperTestsBase
+{
+    [Test]
+    [MoqInlineAutoData("<p>Hello, world!</p>")]
+    [MoqInlineAutoData("<p>Hello, world!</p><u>Underline</u><p>Another paragraph</p><b>Bold</b><i>Italic</i></br>")]
+    [MoqInlineAutoData("<p>Hello, world!</p><ul><li>item</li><li>Another item</li></ul>")]
+    public void ProcessAsync_WhenContentIsHtml_ShouldRenderHtml(string content)
+    {
+        // Arrange
+        var helper = new HtmlContentRendererTagHelper
+        {
+            Content = content
+        };
+
+        var output = new TagHelperOutput("html-content-renderer", [], (s, d) => Task.FromResult<TagHelperContent>(null!));
+
+        // Act
+        helper.ProcessAsync(TagHelperContext, output).Wait();
+
+        // Assert
+        output.Content.GetContent().Should().Contain($"{content}");
+    }
+
+    [Test]
+    [MoqInlineAutoData("")]
+    [MoqInlineAutoData(null)]
+    public void ProcessAsync_WhenContentIsHtml_When_Null_Or_Empty_ShouldRenderHtml(string content)
+    {
+        // Arrange
+        var helper = new HtmlContentRendererTagHelper
+        {
+            Content = content
+        };
+
+        var output = new TagHelperOutput("html-content-renderer", [], (s, d) => Task.FromResult<TagHelperContent>(null!));
+
+        // Act
+        helper.ProcessAsync(TagHelperContext, output).Wait();
+
+        // Assert
+        output.Content.GetContent().Should().BeNullOrEmpty();
+    }
+
+    [Test, MoqAutoData]
+    public void ProcessAsync_WhenContentIsPlainText_ShouldRenderWrappedHtml(string content)
+    {
+        // Arrange
+        var helper = new HtmlContentRendererTagHelper
+        {
+            Content = content
+        };
+
+        var output = new TagHelperOutput("html-content-renderer", [], (s, d) => Task.FromResult<TagHelperContent>(null!));
+        
+        // Act
+        helper.ProcessAsync(TagHelperContext, output).Wait();
+
+        // Assert
+        output.Content.GetContent().Should().Contain($"<p class='govuk-body govuk-!-margin-bottom-0'>{content}</p>");
+    }
+}

--- a/src/SFA.DAS.FAA.Web/SFA.DAS.FAA.Web.csproj
+++ b/src/SFA.DAS.FAA.Web/SFA.DAS.FAA.Web.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UseRazorSourceGenerator>false</UseRazorSourceGenerator>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.18.0" />

--- a/src/SFA.DAS.FAA.Web/TagHelpers/HtmlContentRendererTagHelper.cs
+++ b/src/SFA.DAS.FAA.Web/TagHelpers/HtmlContentRendererTagHelper.cs
@@ -17,7 +17,7 @@ public class HtmlContentRendererTagHelper : TagHelper
     private static readonly Regex HtmlTagRegex = new(@"<\s*/?\s*[a-zA-Z][a-zA-Z0-9]*(\s[^<>]*)?\s*/?\s*>", RegexOptions.None, TimeSpan.FromMilliseconds(100));
 
     [HtmlAttributeName("content")]
-    public string? Content { get; init; }
+    public string? Content { get; set; }
 
     public override void Process(TagHelperContext context, TagHelperOutput output)
     {

--- a/src/SFA.DAS.FAA.Web/TagHelpers/HtmlContentRendererTagHelper.cs
+++ b/src/SFA.DAS.FAA.Web/TagHelpers/HtmlContentRendererTagHelper.cs
@@ -14,12 +14,10 @@ public class HtmlContentRendererTagHelper : TagHelper
     private const string TagName = "html-content-renderer";
 
     // Matches an opening or closing HTML tag, e.g. <p>, </p>, <br/>, <a href="...">
-    private static readonly Regex HtmlTagRegex = new(
-        @"<\s*/?\s*[a-zA-Z][a-zA-Z0-9]*(\s[^<>]*)?\s*/?\s*>",
-        RegexOptions.Compiled);
+    private static readonly Regex HtmlTagRegex = new(@"<\s*/?\s*[a-zA-Z][a-zA-Z0-9]*(\s[^<>]*)?\s*/?\s*>", RegexOptions.None, TimeSpan.FromMilliseconds(100));
 
     [HtmlAttributeName("content")]
-    public string? Content { get; set; }
+    public string? Content { get; init; }
 
     public override void Process(TagHelperContext context, TagHelperOutput output)
     {

--- a/src/SFA.DAS.FAA.Web/TagHelpers/HtmlContentRendererTagHelper.cs
+++ b/src/SFA.DAS.FAA.Web/TagHelpers/HtmlContentRendererTagHelper.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+using System.Text.Encodings.Web;
+using System.Text.RegularExpressions;
+
+namespace SFA.DAS.FAA.Web.TagHelpers;
+
+/// <summary>
+/// Renders the supplied content either as raw HTML (when it already contains markup)
+/// or wrapped in a GOV.UK-style paragraph (when it is plain text).
+/// </summary>
+[HtmlTargetElement(TagName)]
+public class HtmlContentRendererTagHelper : TagHelper
+{
+    private const string TagName = "html-content-renderer";
+
+    // Matches an opening or closing HTML tag, e.g. <p>, </p>, <br/>, <a href="...">
+    private static readonly Regex HtmlTagRegex = new(
+        @"<\s*/?\s*[a-zA-Z][a-zA-Z0-9]*(\s[^<>]*)?\s*/?\s*>",
+        RegexOptions.Compiled);
+
+    [HtmlAttributeName("content")]
+    public string? Content { get; set; }
+
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        if (string.IsNullOrWhiteSpace(Content))
+        {
+            output.SuppressOutput();
+            return;
+        }
+
+        // We don't want the <html-content-renderer> element itself to appear in the
+        // output - just whichever element we decide to emit below.
+        output.TagName = null;
+
+        var text = Content.Trim();
+
+        if (HtmlTagRegex.IsMatch(text))
+        {
+            // Already contains markup - trust it and render as-is.
+            output.Content.SetHtmlContent(text);
+        }
+        else
+        {
+            // Plain text - encode defensively (handles stray & < > etc.), then wrap.
+            var encoded = HtmlEncoder.Default.Encode(text);
+            output.Content.SetHtmlContent($"<p class='govuk-body govuk-!-margin-bottom-0'>{encoded}</p>");
+        }
+    }
+}

--- a/src/SFA.DAS.FAA.Web/Views/Vacancies/_RaaVacancy.cshtml
+++ b/src/SFA.DAS.FAA.Web/Views/Vacancies/_RaaVacancy.cshtml
@@ -30,8 +30,10 @@
 }
 else
 {
-    @if (Model.ApplicationDetails is { Status: ApplicationStatus.Submitted } or { Status: ApplicationStatus.Successful } or
-        { Status: ApplicationStatus.Unsuccessful })
+    @if (Model.ApplicationDetails is 
+    { Status: ApplicationStatus.Submitted }or
+    { Status: ApplicationStatus.Successful } or
+    { Status: ApplicationStatus.Unsuccessful })
     {
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
@@ -266,9 +268,7 @@ else
                         }
                     </div>
                 </div>
-                <p>
-                    @Html.Raw(Model.VacancySummary)
-                </p>
+                <html-content-renderer content="@Model.VacancySummary"></html-content-renderer>
                 <dl class="govuk-summary-list">
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">
@@ -285,9 +285,9 @@ else
                             </p>
                             @if (!string.IsNullOrWhiteSpace(Model.WageAdditionalInformation))
                             {
-                                <p class="govuk-body govuk-!-padding-top-3">
-                                    @Html.Raw(Model.WageAdditionalInformation)
-                                </p>
+                                <div class="govuk-!-padding-top-3">
+                                    <html-content-renderer content="@Model.WageAdditionalInformation"></html-content-renderer>
+                                </div>
                             }
                         </dd>
                     </div>
@@ -342,7 +342,7 @@ else
                     Most of your apprenticeship is spent working. You’ll learn on the job by getting hands-on experience.
                 </p>
                 <h3 class="govuk-heading-s">What you'll do at work</h3>
-                <p>@Html.Raw(Model.WorkDescription)</p>
+                <html-content-renderer content="@Model.WorkDescription"></html-content-renderer>
                 <h3 class="govuk-heading-s">Where you'll work</h3>
                 @switch (Model.EmployerLocationOption)
                 {
@@ -361,9 +361,7 @@ else
                             break;
                         }
                     case AvailableWhere.AcrossEngland:
-                        <p class="govuk-body">
-                            @Html.Raw(Model.EmploymentLocationInformation)
-                        </p>
+                        <html-content-renderer content="@Model.EmploymentLocationInformation"></html-content-renderer>
                         break;
                     default:
                         <address class="govuk-body" value="Model.WorkLocation" anonymised="Model.IsAnonymousEmployer"></address>
@@ -482,23 +480,19 @@ else
                 }
                 else
                 {
-                    <p>@Html.Raw(Model.TrainingPlan)</p>
+                    <html-content-renderer content="@Model.TrainingPlan"></html-content-renderer>
                 }
                 @if (!string.IsNullOrEmpty(Model.AdditionalTrainingInformation))
                 {
                     <h3 class="govuk-heading-s">More training information</h3>
-                    <p>
-                        @Html.Raw(@Model.AdditionalTrainingInformation)
-                    </p>
+                    <html-content-renderer content="@Model.AdditionalTrainingInformation"></html-content-renderer>
                 }
             </section>
             <section class="faa-vacancy__section" id="requirements">
                 <h2 class="govuk-heading-m">Requirements</h2>
-
                 <p asp-show="@Model.ApprenticeshipType.IsFoundation()" class="govuk-hint">
                     You do not need to have any specific qualifications or experience to apply for a foundation apprenticeship.
                 </p>
-
                 @if (!Model.ApprenticeshipType.IsFoundation())
                 {
                     if (Model.EssentialQualifications is { Count: > 0 })
@@ -529,16 +523,12 @@ else
                 @if (!string.IsNullOrEmpty(Model.ThingsToConsider))
                 {
                     <h3 class="govuk-heading-s">Other requirements</h3>
-                    <p>
-                        @Html.Raw(Model.ThingsToConsider)
-                    </p>
+                    <html-content-renderer content="@Model.ThingsToConsider"></html-content-renderer>
                 }
             </section>
             <section class="faa-vacancy__section" id="company">
                 <h2 class="govuk-heading-m">About this employer</h2>
-                <p>
-                    @Html.Raw(Model.EmployerDescription)
-                </p>
+                <html-content-renderer content="@Model.EmployerDescription"></html-content-renderer>
                 @if (!string.IsNullOrEmpty(Model.EmployerWebsite))
                 {
                     <p class="govuk-body">
@@ -549,9 +539,8 @@ else
                 @if (!string.IsNullOrEmpty(Model.CompanyBenefits))
                 {
                     <h3 class="govuk-heading-s">Company benefits</h3>
-                    <p>
-                        @Html.Raw(Model.CompanyBenefits)
-                    </p>
+                    <html-content-renderer content="@Model.CompanyBenefits"></html-content-renderer>
+                   
                 }
                 @if (Model.IsDisabilityConfident)
                 {
@@ -573,9 +562,7 @@ else
                     <p class="govuk-body das-!-color-dark-grey">
                     Your earnings can increase over time with an apprenticeship. <a href="https://www.apprenticeships.gov.uk/apprentices/apprentice-pay-and-future-salary" class="govuk-link govuk-link--no-visited-state" target="_blank">Find out about potential future pay (opens in new tab).</a>
                 </p>
-                <p>
-                    @Html.Raw(Model.OutcomeDescription)
-                </p>
+                <html-content-renderer content="@Model.OutcomeDescription"></html-content-renderer>
             </section>
             <section class="faa-vacancy__section" id="question">
                 <h2 class="govuk-heading-m">Ask a question</h2>
@@ -640,7 +627,6 @@ else
                         else
                         {
                             <h2 class="govuk-heading-m">Apply now</h2>
-
                             <div asp-show="@(Model.ApprenticeshipType.IsFoundation() && (Model.CandidateIs21OrUnderAtStartOfVacancy || Model.CandidateIs22To24AtStartOfVacancy || Model.CandidateIs25OrOverAtStartOfVacancy))" class="govuk-inset-text faa-foundation-inset-text">
                                 @if (Model.CandidateIs21OrUnderAtStartOfVacancy)
                                 {


### PR DESCRIPTION
Add HtmlContentRendererTagHelper and update vacancy view

Introduced HtmlContentRendererTagHelper to render HTML or wrap plain text in GOV.UK-style paragraphs. Added unit tests for the tag helper. Refactored _RaaVacancy.cshtml to use the new tag helper instead of @Html.Raw for improved consistency and security.