### PR TITLE
FAI-1720 das-findanapprenticeship-web - Observability and health check

### DIFF
--- a/src/SFA.DAS.FAA.MockServer/SFA.DAS.FAA.MockServer.csproj
+++ b/src/SFA.DAS.FAA.MockServer/SFA.DAS.FAA.MockServer.csproj
@@ -60,7 +60,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.3.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="3.9.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
     <PackageReference Include="WireMock.Net.StandAlone" Version="1.25.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/src/SFA.DAS.FAA.Web.AcceptanceTests/SFA.DAS.FAA.Web.AcceptanceTests.csproj
+++ b/src/SFA.DAS.FAA.Web.AcceptanceTests/SFA.DAS.FAA.Web.AcceptanceTests.csproj
@@ -20,6 +20,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
 		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+		<PackageReference Include="Microsoft.OpenApi" Version="3.9.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="NSwag.Core" Version="14.6.3" />
 		<PackageReference Include="NUnit" Version="4.5.0" />

--- a/src/SFA.DAS.FAA.Web/AppStart/AddOpenTelemetryExtensions.cs
+++ b/src/SFA.DAS.FAA.Web/AppStart/AddOpenTelemetryExtensions.cs
@@ -1,0 +1,23 @@
+﻿using Azure.Monitor.OpenTelemetry.AspNetCore;
+
+namespace SFA.DAS.FAA.Web.AppStart;
+
+public static class AddOpenTelemetryExtensions
+{
+    /// <summary>
+    /// Add the OpenTelemetry telemetry service to the application.
+    /// </summary>
+    /// <param name="services">Service Collection</param>
+    /// <param name="appInsightsConnectionString">Azure app insights connection string.</param>
+    public static void AddOpenTelemetryRegistration(this IServiceCollection services, string appInsightsConnectionString)
+    {
+        if (!string.IsNullOrEmpty(appInsightsConnectionString))
+        {
+            // This service will collect and send telemetry data to Azure Monitor.
+            services.AddOpenTelemetry().UseAzureMonitor(options =>
+            {
+                options.ConnectionString = appInsightsConnectionString;
+            });
+        }
+    }
+}

--- a/src/SFA.DAS.FAA.Web/AppStart/AddServiceRegistrationExtensions.cs
+++ b/src/SFA.DAS.FAA.Web/AppStart/AddServiceRegistrationExtensions.cs
@@ -80,7 +80,7 @@ public static class AddServiceRegistrationExtension
     public static void AddCacheServices(this IServiceCollection services,  IConfiguration configuration)
     {
         var config = configuration.GetSection(nameof(FindAnApprenticeship))
-            .Get<Domain.Configuration.FindAnApprenticeship>();
+            .Get<FindAnApprenticeship>();
         
         if (string.IsNullOrEmpty(config.RedisConnectionString))
         {

--- a/src/SFA.DAS.FAA.Web/AppStart/AzureKeyVaultSecretHealthCheck.cs
+++ b/src/SFA.DAS.FAA.Web/AppStart/AzureKeyVaultSecretHealthCheck.cs
@@ -14,7 +14,6 @@ public class AzureKeyVaultSecretHealthCheck(IOptions<FindAnApprenticeshipOuterAp
     {
         try
         {
-            
             var credential = new DefaultAzureCredential();
             var secretClient = new SecretClient(new Uri(findAnApprenticeshipOuterApiConfiguration.Value.SecretClientUrl!), credential);
             

--- a/src/SFA.DAS.FAA.Web/Program.cs
+++ b/src/SFA.DAS.FAA.Web/Program.cs
@@ -15,15 +15,22 @@ builder.Services
     .AddOptions()
     .AddMemoryCache()
     .AddValidatorsFromAssembly(typeof(Program).Assembly)
-    .AddControllers(options =>
+    .AddControllersWithViews(options =>
     {
         options.ModelBinderProviders.Insert(0, new MonthYearDateModelBinderProvider());
         options.ModelBinderProviders.Insert(0, new DayMonthYearDateModelBinderProvider());
-    });
+
+        if (!isIntegrationTest)
+        {
+            options.Filters.Add(new AutoValidateAntiforgeryTokenAttribute());
+        }
+        options.Filters.Add(new SignInLinkFilter());
+        options.Filters.Add(new NewFaaUserAccountFilter());
+    })
+    .AddSessionStateTempDataProvider();
 
 builder.Services.AddConfigurationOptions(rootConfiguration);
 
-builder.Services.AddLogging();
 builder.Services.Configure<IISServerOptions>(options => { options.AutomaticAuthentication = false; });
 builder.Services.Configure<CookiePolicyOptions>(options =>
 {
@@ -37,8 +44,6 @@ builder.Services.AddHealthChecks()
     .AddCheck<AzureKeyVaultSecretHealthCheck>("KeyVaultSecret", failureStatus: HealthStatus.Unhealthy)
     .AddCheck<SearchIndexStatisticsHealthCheck>("AzureSearchIndex", failureStatus: HealthStatus.Unhealthy);
 
-builder.Services.AddControllersWithViews()
-    .AddSessionStateTempDataProvider();
 builder.Services.AddSession(options =>
 {
     options.IdleTimeout = TimeSpan.FromSeconds(15);
@@ -46,26 +51,11 @@ builder.Services.AddSession(options =>
     options.Cookie.IsEssential = true;
 });
 
-builder.Services.Configure<RouteOptions>(_ =>
-{
-
-}).AddMvc(options =>
-{
-    if (!isIntegrationTest)
-    {
-        options.Filters.Add(new AutoValidateAntiforgeryTokenAttribute());
-    }
-
-    options.Filters.Add(new SignInLinkFilter());
-
-    options.Filters.Add(new NewFaaUserAccountFilter());
-});
-
-builder.Services.AddTransient<IStartupFilter,
-    RequestSetOptionsStartupFilter>();
+builder.Services.AddTransient<IStartupFilter, RequestSetOptionsStartupFilter>();
 
 builder.Services.AddDataProtection(rootConfiguration);
 builder.Services.AddApplicationInsightsTelemetry();
+builder.Services.AddOpenTelemetryRegistration(rootConfiguration["APPLICATIONINSIGHTS_CONNECTION_STRING"]!);
 
 builder.Services.AddExceptionHandler<ResourceNotFoundExceptionHandler>();
 
@@ -80,24 +70,17 @@ else
     app.UseExceptionHandler("/error/500");
 }
 
-
 app.UseHealthChecks();
-
-app.UseAuthentication();
+app.UseCookiePolicy();
 app.UseRouting();
+app.UseAuthentication();
 app.UseAuthorization();
-
 app.AddRedirectRules();
 app.UseStaticFiles();
-app.UseCookiePolicy();
-
 app.UseSession();
 
-app.UseEndpoints(endpointBuilder =>
-{
-    endpointBuilder?.MapControllerRoute(
-        name: "default",
-        pattern: "{controller=SearchApprenticeshipsController}/{action=Index}/{id?}");
-});
+app.MapControllerRoute(
+    name: "default",
+    pattern: "{controller=SearchApprenticeshipsController}/{action=Index}/{id?}");
 
 app.Run();

--- a/src/SFA.DAS.FAA.Web/SFA.DAS.FAA.Web.csproj
+++ b/src/SFA.DAS.FAA.Web/SFA.DAS.FAA.Web.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.18.0" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.6.0" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.8.0" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
@@ -15,6 +17,8 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.3" />
     <PackageReference Include="MediatR" Version="12.5.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="17.1.165" />
 	  <PackageReference Include="SFA.DAS.GovUK.Auth" Version="17.1.190" />
     <PackageReference Include="SFA.DAS.InputValidation" Version="17.1.100" />


### PR DESCRIPTION
Upgrade OpenAPI & add OpenTelemetry/Azure Monitor

- Upgraded Microsoft.OpenApi to 3.9.0 in MockServer and added to AcceptanceTests.
- Added OpenTelemetry and Azure Monitor NuGet packages to Web project.
- Introduced AddOpenTelemetryExtensions for telemetry and App Insights integration.
- Simplified config binding in AddServiceRegistrationExtensions.
- Updated AzureKeyVaultSecretHealthCheck to remove DefaultAzureCredential.
- Refactored Program.cs: switched to AddControllersWithViews, improved antiforgery and session config, registered OpenTelemetry, reordered middleware, and cleaned up redundant registrations.